### PR TITLE
Prq

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/fizyk20/rust-mpfr.git"
 
 [lib]
 name = "rust_mpfr"
-crate-type = ["dylib"]
+crate-type = ["rlib", "dylib"]
 
 [dependencies]
 libc = "0.1.8"

--- a/src/mpfr.rs
+++ b/src/mpfr.rs
@@ -92,6 +92,9 @@ extern "C" {
     fn mpfr_pow(rop: mpfr_ptr, op1: mpfr_srcptr, op2: mpfr_srcptr, rnd: mpfr_rnd_t) -> c_int;
     fn mpfr_exp(rop: mpfr_ptr, op: mpfr_srcptr, rnd: mpfr_rnd_t) -> c_int;
     fn mpfr_log(rop: mpfr_ptr, op: mpfr_srcptr, rnd: mpfr_rnd_t) -> c_int;
+    fn mpfr_gamma(rop: mpfr_ptr, op: mpfr_srcptr, rnd: mpfr_rnd_t) -> c_int;
+    fn mpfr_lngamma(rop: mpfr_ptr, op: mpfr_srcptr, rnd: mpfr_rnd_t) -> c_int;
+    fn mpfr_lgamma(rop: mpfr_ptr, op: mpfr_srcptr, rnd: mpfr_rnd_t) -> c_int;
 }
 
 pub struct Mpfr {
@@ -279,6 +282,30 @@ impl Mpfr {
         unsafe {
             let mut res = Mpfr::new2(self.get_prec());
             mpfr_log(&mut res.mpfr, &self.mpfr, mpfr_rnd_t::MPFR_RNDN);
+            res
+        }
+    }
+
+    pub fn gamma(&self) -> Mpfr {
+        unsafe {
+            let mut res = Mpfr::new2(self.get_prec());
+            mpfr_gamma(&mut res.mpfr, &self.mpfr, mpfr_rnd_t::MPFR_RNDN);
+            res
+        }
+    }
+
+    pub fn lngamma(&self) -> Mpfr {
+        unsafe {
+            let mut res = Mpfr::new2(self.get_prec());
+            mpfr_lngamma(&mut res.mpfr, &self.mpfr, mpfr_rnd_t::MPFR_RNDN);
+            res
+        }
+    }
+
+    pub fn lgamma(&self) -> Mpfr {
+        unsafe {
+            let mut res = Mpfr::new2(self.get_prec());
+            mpfr_lgamma(&mut res.mpfr, &self.mpfr, mpfr_rnd_t::MPFR_RNDN);
             res
         }
     }

--- a/src/mpfr.rs
+++ b/src/mpfr.rs
@@ -92,6 +92,7 @@ extern "C" {
     fn mpfr_cbrt(rop: mpfr_ptr, op: mpfr_srcptr, rnd: mpfr_rnd_t) -> c_int;
     fn mpfr_root(rop: mpfr_ptr, op: mpfr_srcptr, k: c_ulong, rnd: mpfr_rnd_t) -> c_int;
     fn mpfr_pow(rop: mpfr_ptr, op1: mpfr_srcptr, op2: mpfr_srcptr, rnd: mpfr_rnd_t) -> c_int;
+    fn mpfr_abs(rop: mpfr_ptr, op: mpfr_srcptr, rnd: mpfr_rnd_t) -> c_int;
     fn mpfr_exp(rop: mpfr_ptr, op: mpfr_srcptr, rnd: mpfr_rnd_t) -> c_int;
     fn mpfr_log(rop: mpfr_ptr, op: mpfr_srcptr, rnd: mpfr_rnd_t) -> c_int;
     fn mpfr_gamma(rop: mpfr_ptr, op: mpfr_srcptr, rnd: mpfr_rnd_t) -> c_int;
@@ -298,6 +299,14 @@ impl Mpfr {
         unsafe {
             let mut res = Mpfr::new2(self.get_prec());
             mpfr_pow(&mut res.mpfr, &self.mpfr, &other.mpfr, mpfr_rnd_t::MPFR_RNDN);
+            res
+        }
+    }
+
+    pub fn abs(&self) -> Mpfr {
+        unsafe {
+            let mut res = Mpfr::new2(self.get_prec());
+            mpfr_abs(&mut res.mpfr, &self.mpfr, mpfr_rnd_t::MPFR_RNDN);
             res
         }
     }

--- a/src/test.rs
+++ b/src/test.rs
@@ -175,3 +175,11 @@ fn test_new2_from_str() {
         assert!(a - b < From::from(epsilon) || c - d > From::from(-epsilon));
     }
 }
+
+#[test]
+fn test_abs() {
+    let a: Mpfr = From::<i64>::from(1);
+    let b: Mpfr = From::<i64>::from(-1);
+
+    assert!(a.abs() == b.abs());
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -139,3 +139,39 @@ fn test_exp_log() {
 	assert!(a.exp() == b);
 	assert!(b.log() == a);
 }
+
+#[test]
+fn test_new_from_str() {
+    let a: Mpfr = From::<i64>::from(1);
+    let b: Mpfr = Mpfr::new_from_str("1", 10).unwrap();
+
+    assert!(a == b);
+
+    let a: Mpfr = From::<f64>::from(1.234);
+    let b: Mpfr = Mpfr::new_from_str("1.234", 10).unwrap();
+
+    assert!(a == b);
+}
+
+#[test]
+fn test_new2_from_str() {
+    let epsilon = 1e-100f64;
+
+    {
+        let a: Mpfr = From::<i64>::from(1);
+        let b: Mpfr = Mpfr::new2_from_str(200, "1", 10).unwrap();
+        let c = a.clone();
+        let d = b.clone();
+
+        assert!(a - b < From::from(epsilon) || c - d > From::from(-epsilon));
+    }
+
+    {
+        let a: Mpfr = From::<f64>::from(1.234);
+        let b: Mpfr = Mpfr::new2_from_str(200, "1.234", 10).unwrap();
+        let c = a.clone();
+        let d = b.clone();
+
+        assert!(a - b < From::from(epsilon) || c - d > From::from(-epsilon));
+    }
+}


### PR DESCRIPTION
I had some stuff to calculate and relized that f64 is not enough so mpfr was a good candidate and I found your wrapper library on crates.io. When I started to use it in my program I realized that there was no gamma functions or any absolute value functions., so I added them. I also got a problem during linking, which was solved by adding "rlib" to the crate-type list.

I could not figure out how to get a high precision value initialized from a f64, for example into a Mpfr, so I added wrappers for mpfr_set_str(). Since these can fail, I made them return Option<Mpfr>. I have not written a lot of unsafe code before, they are not leaking memory or doing anything else nasty. 
