### PR TITLE
Implement ToString for Mpfr.

### DIFF
--- a/src/mpfr.rs
+++ b/src/mpfr.rs
@@ -1,13 +1,17 @@
 use gmp::mpf::{Mpf, mpf_ptr, mpf_srcptr};
 use gmp::mpq::{Mpq, mpq_srcptr};
 use gmp::mpz::{Mpz, mpz_ptr, mpz_srcptr};
-use libc::{c_char, c_int, c_ulong, c_long, c_double, c_void};
+use libc::{c_char, c_int, c_ulong, c_long, c_double, c_void, size_t};
+use std::ffi::{CStr};
 use std::cmp::{Eq, PartialEq, Ord, PartialOrd, Ordering};
 use std::cmp;
 use std::convert::{From, Into};
 use std::ffi::CString;
 use std::mem::uninitialized;
 use std::ops::{Add, Sub, Mul, Div, Neg};
+use std::str;
+use std::string::{ToString};
+use std::ptr;
 
 type mpfr_prec_t = c_long;
 type mpfr_sign_t = c_int;
@@ -45,6 +49,7 @@ extern "C" {
 	fn mpfr_get_default_prec() -> mpfr_prec_t;
 	fn mpfr_set_prec(x: mpfr_ptr, prec: mpfr_prec_t);
 	fn mpfr_get_prec(x: mpfr_srcptr) -> mpfr_prec_t;
+    fn mpfr_snprintf(buffer: *const c_char, length: size_t, string: *const u8, ...) -> c_int;
 	
 	// Assignment
 	fn mpfr_set(rop: mpfr_ptr, op: mpfr_srcptr, rnd: mpfr_rnd_t) -> c_int;
@@ -112,6 +117,21 @@ extern "C" {
 
 pub struct Mpfr {
     pub mpfr: mpfr_struct,
+}
+
+impl ToString for Mpfr {
+    fn to_string(&self) -> String {
+        unsafe {
+            let length = mpfr_snprintf(ptr::null(), 0, b"%.Re\0".as_ptr(), &self.mpfr);
+            let buff : Vec<c_char> = Vec::with_capacity((length + 1) as usize);
+            mpfr_snprintf(buff.as_ptr(),
+                          (length + 1) as size_t,
+                          b"%.Re\0".as_ptr(),
+                          &self.mpfr);
+            let s = CStr::from_ptr(buff.as_ptr());
+            str::from_utf8(s.to_bytes()).unwrap().to_string()
+        }
+    }
 }
 
 unsafe impl Send for Mpfr { }

--- a/src/test.rs
+++ b/src/test.rs
@@ -177,6 +177,20 @@ fn test_new2_from_str() {
 }
 
 #[test]
+fn test_to_string() {
+    let a: Mpfr = Mpfr::new2_from_str(128, "1.23456789123456789123456789123456789e5", 10).unwrap();
+
+    assert_eq!(a.to_string(), "1.23456789123456789123456789123456789e+05");
+}
+
+#[test]
+fn test_to_string_new2_from_str() {
+    let a: Mpfr = Mpfr::new2_from_str(128, "1.23456789123456789123456789123456789e5", 10).unwrap();
+
+    assert!(a == Mpfr::new2_from_str(128, a.to_string(), 10).unwrap());
+}
+
+#[test]
 fn test_abs() {
     let a: Mpfr = From::<i64>::from(1);
     let b: Mpfr = From::<i64>::from(-1);


### PR DESCRIPTION
Fixed point output via the f and g output for doesn't seem to work, so the
output is in scientific format.
