### PR TITLE
rustc_serialize support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ crate-type = ["rlib", "dylib"]
 [dependencies]
 libc = "*"
 rust-gmp = "*"
+rustc-serialize = "~0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 
 extern crate libc;
 extern crate gmp;
+extern crate rustc_serialize;
 
 macro_rules! gen_overloads_inner {
     ($tr:ident, $meth:ident, $T:ident) => {

--- a/src/mpfr.rs
+++ b/src/mpfr.rs
@@ -2,6 +2,7 @@ use gmp::mpf::{Mpf, mpf_ptr, mpf_srcptr};
 use gmp::mpq::{Mpq, mpq_srcptr};
 use gmp::mpz::{Mpz, mpz_ptr, mpz_srcptr};
 use libc::{c_char, c_int, c_ulong, c_long, c_double, c_void, size_t};
+use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use std::ffi::CStr;
 use std::cmp::{Eq, PartialEq, Ord, PartialOrd, Ordering};
 use std::cmp;
@@ -1198,3 +1199,20 @@ impl Neg for Mpfr {
 }
 
 gen_overloads!(Mpfr);
+
+// rustc_serialize support
+impl Decodable for Mpfr {
+    fn decode<D: Decoder>(d: &mut D) -> Result<Self, D::Error> {
+        let s = try!(d.read_str());
+        match Mpfr::new_from_str(s, 10) {
+            Some(val) => Ok(val),
+            None => Err(d.error("Cannot parse decimal float")),
+        }
+    }
+}
+
+impl Encodable for Mpfr {
+    fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
+        s.emit_str(&self.to_string())
+    }
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,3 +1,5 @@
+use rustc_serialize::json;
+
 use super::mpfr::Mpfr;
 
 #[test]
@@ -196,4 +198,16 @@ fn test_abs() {
     let b: Mpfr = From::<i64>::from(-1);
 
     assert!(a.abs() == b.abs());
+}
+
+#[test]
+fn test_rustc_serialize() {
+    #[derive(RustcDecodable, RustcEncodable, PartialEq)]
+    struct Test {
+        price: Mpfr,
+    }
+    let a: Test = Test { price: From::<f64>::from(0.75) };
+    assert_eq!(json::encode(&a).unwrap(), "{\"price\":\"7.5e-01\"}");
+    let b: Test = json::decode("{\"price\": \"0.75\"}").unwrap();
+    assert!(a == b);
 }


### PR DESCRIPTION
Add support for rustc_serialize for mprf. This allows it to be seamlessly used as a field in json structs.
