### PR TITLE
Add mpfr macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,13 @@ macro_rules! gen_overloads {
     }
 }
 
+#[macro_export]
+macro_rules! mpfr {
+    ($t:tt) => {
+        $crate::mpfr::Mpfr::new_from_str(stringify!($t), 10).expect("Invalid floating point literal")
+    }
+}
+
 pub mod mpfr;
 
 #[cfg(test)]

--- a/src/mpfr.rs
+++ b/src/mpfr.rs
@@ -8,10 +8,10 @@ use std::cmp::{Eq, PartialEq, Ord, PartialOrd, Ordering};
 use std::cmp;
 use std::convert::{From, Into};
 use std::ffi::CString;
-use std::fmt;
 use std::mem::uninitialized;
 use std::ops::{Add, Sub, Mul, Div, Neg};
 use std::str;
+use std::string::ToString;
 use std::ptr;
 
 type mpfr_prec_t = c_long;
@@ -122,19 +122,12 @@ pub struct Mpfr {
     pub mpfr: mpfr_struct,
 }
 
-impl fmt::Debug for Mpfr {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Display::fmt(&self, fmt)
-    }
-}
-
-impl fmt::Display for Mpfr {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+impl ToString for Mpfr {
+    fn to_string(&self) -> String {
         unsafe {
             let length = mpfr_snprintf(ptr::null(), 0, b"%.Re\0".as_ptr(), &self.mpfr);
             if length < 0 {
-                // Maybe fmt.write_str("@uninnitialized@")
-                return Ok(())
+                return "".to_string();
             }
             let buff: Vec<c_char> = Vec::with_capacity((length + 1) as usize);
             mpfr_snprintf(buff.as_ptr(),
@@ -142,7 +135,7 @@ impl fmt::Display for Mpfr {
                           b"%.Re\0".as_ptr(),
                           &self.mpfr);
             let s = CStr::from_ptr(buff.as_ptr());
-            fmt.write_str(str::from_utf8_unchecked(s.to_bytes()))
+            str::from_utf8(s.to_bytes()).unwrap().to_string()
         }
     }
 }

--- a/src/mpfr.rs
+++ b/src/mpfr.rs
@@ -8,10 +8,10 @@ use std::cmp::{Eq, PartialEq, Ord, PartialOrd, Ordering};
 use std::cmp;
 use std::convert::{From, Into};
 use std::ffi::CString;
+use std::fmt;
 use std::mem::uninitialized;
 use std::ops::{Add, Sub, Mul, Div, Neg};
 use std::str;
-use std::string::ToString;
 use std::ptr;
 
 type mpfr_prec_t = c_long;
@@ -122,12 +122,19 @@ pub struct Mpfr {
     pub mpfr: mpfr_struct,
 }
 
-impl ToString for Mpfr {
-    fn to_string(&self) -> String {
+impl fmt::Debug for Mpfr {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&self, fmt)
+    }
+}
+
+impl fmt::Display for Mpfr {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         unsafe {
             let length = mpfr_snprintf(ptr::null(), 0, b"%.Re\0".as_ptr(), &self.mpfr);
             if length < 0 {
-                return "".to_string();
+                // Maybe fmt.write_str("@uninnitialized@")
+                return Ok(())
             }
             let buff: Vec<c_char> = Vec::with_capacity((length + 1) as usize);
             mpfr_snprintf(buff.as_ptr(),
@@ -135,7 +142,7 @@ impl ToString for Mpfr {
                           b"%.Re\0".as_ptr(),
                           &self.mpfr);
             let s = CStr::from_ptr(buff.as_ptr());
-            str::from_utf8(s.to_bytes()).unwrap().to_string()
+            fmt.write_str(str::from_utf8_unchecked(s.to_bytes()))
         }
     }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -185,20 +185,6 @@ fn test_mpfr_macro() {
 }
 
 #[test]
-fn test_debug() {
-    let a: Mpfr = Mpfr::new2_from_str(128, "1.23456789123456789123456789123456789e5", 10).unwrap();
-
-    assert_eq!(format!("{:?}", a), "1.23456789123456789123456789123456789e+05");
-}
-
-#[test]
-fn test_display() {
-    let a: Mpfr = Mpfr::new2_from_str(128, "1.23456789123456789123456789123456789e5", 10).unwrap();
-
-    assert_eq!(format!("{}", a), "1.23456789123456789123456789123456789e+05");
-}
-
-#[test]
 fn test_to_string() {
     let a: Mpfr = Mpfr::new2_from_str(128, "1.23456789123456789123456789123456789e5", 10).unwrap();
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -179,6 +179,12 @@ fn test_new2_from_str() {
 }
 
 #[test]
+fn test_mpfr_macro() {
+    let a: Mpfr = Mpfr::new_from_str("0.123456789012345678901234567890", 10).unwrap();
+    assert_eq!(mpfr!(0.123456789012345678901234567890), a);
+}
+
+#[test]
 fn test_debug() {
     let a: Mpfr = Mpfr::new2_from_str(128, "1.23456789123456789123456789123456789e5", 10).unwrap();
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -179,6 +179,20 @@ fn test_new2_from_str() {
 }
 
 #[test]
+fn test_debug() {
+    let a: Mpfr = Mpfr::new2_from_str(128, "1.23456789123456789123456789123456789e5", 10).unwrap();
+
+    assert_eq!(format!("{:?}", a), "1.23456789123456789123456789123456789e+05");
+}
+
+#[test]
+fn test_display() {
+    let a: Mpfr = Mpfr::new2_from_str(128, "1.23456789123456789123456789123456789e5", 10).unwrap();
+
+    assert_eq!(format!("{}", a), "1.23456789123456789123456789123456789e+05");
+}
+
+#[test]
 fn test_to_string() {
     let a: Mpfr = Mpfr::new2_from_str(128, "1.23456789123456789123456789123456789e5", 10).unwrap();
 


### PR DESCRIPTION
Usage as follows:

mpfr!(1.23412e12)
mpfr!(0.0001)

This makes it easier to write mpfr literals.
