### PR TITLE
Bug fix for mpfr macro.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,8 +35,8 @@ macro_rules! gen_overloads {
 
 #[macro_export]
 macro_rules! mpfr {
-    ($t:tt) => {
-        $crate::mpfr::Mpfr::new_from_str(stringify!($t), 10).expect("Invalid floating point literal")
+    ($lit:expr) => {
+        $crate::mpfr::Mpfr::new_from_str(stringify!($lit), 10).expect("Invalid floating point literal")
     }
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -182,6 +182,8 @@ fn test_new2_from_str() {
 fn test_mpfr_macro() {
     let a: Mpfr = Mpfr::new_from_str("0.123456789012345678901234567890", 10).unwrap();
     assert_eq!(mpfr!(0.123456789012345678901234567890), a);
+    let b: Mpfr = Mpfr::new_from_str("-5.", 10).unwrap();
+    assert_eq!(mpfr!(-5.), b);
 }
 
 #[test]


### PR DESCRIPTION
-5. is not a single token tree. Use expr instead.
